### PR TITLE
Fix Events Setup

### DIFF
--- a/DEVNOTES.md
+++ b/DEVNOTES.md
@@ -1,0 +1,4 @@
+DEVNOTES
+========
+
+- Remove the General Variables table. It is a sux :D

--- a/events/logo/views.py
+++ b/events/logo/views.py
@@ -3,10 +3,11 @@ from events.logo.models import Submission
 from events.logo.forms import SubmissionForm
 from general import models as generalmodels
 from django.utils import timezone
+from events import models as event_models
 
 
-def check_end():
-    return generalmodels.Variable.objects.get(name='logoend').time <= timezone.now()
+def check_end(event):
+    return event.end_time <= timezone.now()
 
 
 def home(request):
@@ -24,7 +25,8 @@ def gallery(request):
 def submission(request):
     data = {}
     template = 'logo/submission.html'
-    data['ended'] = check_end()
+    logo = event_models.Event.objects.filter(appname='logo', ongoing_event=True).order_by('start_time').last()
+    data['ended'] = check_end(logo)
     if request.method == 'POST':
         form = SubmissionForm(request.POST, request.FILES)
         if form.is_valid():

--- a/events/logo/views.py
+++ b/events/logo/views.py
@@ -25,7 +25,7 @@ def gallery(request):
 def submission(request):
     data = {}
     template = 'logo/submission.html'
-    logo = event_models.Event.objects.filter(appname='logo', ongoing_event=True).order_by('start_time').last()
+    logo = event_models.Event.objects.filter(appname='logo').order_by('start_time').last()
     data['ended'] = check_end(logo)
     if request.method == 'POST':
         form = SubmissionForm(request.POST, request.FILES)

--- a/events/migrations/0005_auto_20170124_1045.py
+++ b/events/migrations/0005_auto_20170124_1045.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('events', '0004_auto_20160313_1548'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='event',
+            name='appname',
+            field=models.CharField(default='orfik', help_text='The name must be known to the app which handles this event. For example orfik', max_length=120),
+        ),
+        migrations.AlterField(
+            model_name='event',
+            name='name',
+            field=models.CharField(help_text='This is the public name of the app. For exmaple Orfik 2055', max_length=120),
+        ),
+    ]

--- a/events/models.py
+++ b/events/models.py
@@ -5,7 +5,9 @@ class Event(models.Model):
     """
     Description: Model for a CompSoc Event
     """
-    name = models.CharField(max_length=120)
+    name = models.CharField(max_length=120, help_text='This is the public name of the app. For exmaple Orfik 2055')
+    appname = models.CharField(max_length=120, help_text='The name must be known to the app which handles this event. For example orfik',
+            default='orfik')
     description = models.TextField()
     fb_event_page = models.CharField(max_length=200)
     start_time = models.DateTimeField()

--- a/events/orfik/migrations/0002_auto_20170124_1053.py
+++ b/events/orfik/migrations/0002_auto_20170124_1053.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import django.utils.timezone
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('events', '0005_auto_20170124_1045'),
+        ('orfik', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='attempt',
+            name='stamp',
+            field=models.DateTimeField(null=True, auto_now_add=True),
+        ),
+        migrations.AddField(
+            model_name='question',
+            name='event',
+            field=models.ForeignKey(to='events.Event', related_name='event_question', default=1),
+            preserve_default=False,
+        ),
+        migrations.AlterField(
+            model_name='player',
+            name='last_solve',
+            field=models.DateTimeField(default=django.utils.timezone.now),
+        ),
+    ]

--- a/events/orfik/models.py
+++ b/events/orfik/models.py
@@ -3,6 +3,7 @@ from django.conf import settings
 from django.db import models
 from django.utils import timezone
 from django.core.urlresolvers import reverse
+from events import models as event_models
 
 
 class Player(models.Model):
@@ -11,7 +12,7 @@ class Player(models.Model):
     nickname = models.CharField(max_length=20)
     user = models.OneToOneField(settings.AUTH_USER_MODEL)
     max_level = models.SmallIntegerField(default=0)
-    last_solve = models.DateTimeField(default=timezone.now())
+    last_solve = models.DateTimeField(default=timezone.now)
 
 
 class Question(models.Model):
@@ -19,6 +20,7 @@ class Question(models.Model):
     text = models.TextField(blank=True, null=True)
     image = models.ImageField(upload_to='question', blank=True, null=True)
     answer = models.CharField(max_length=100)
+    event = models.ForeignKey(event_models.Event, related_name='event_question')
 
     def __str__(self):
         return str(self.number) + ':' + self.text[:15] + ' ...'
@@ -32,16 +34,13 @@ class Attempt(models.Model):
     question = models.ForeignKey(Question, related_name='attempt')
     value = models.CharField(max_length=100)
     correct = models.NullBooleanField(default=None)
+    stamp = models.DateTimeField(auto_now_add=True, null=True, blank=True)
 
 
     def is_correct(self):
-        if self.correct != None:
-            return self.correct
-        if self.question.answer.lower() == self.value.lower():
-            self.correct = True
-        else:
-            self.correct = False
-        self.save()
+        if self.correct is None:
+            self.correct = self.question.answer.lower() == self.value.lower()
+            self.save()
         return self.correct
 
 

--- a/events/orfik/views.py
+++ b/events/orfik/views.py
@@ -3,9 +3,8 @@ from events.orfik import models
 from django.utils import timezone
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth import get_user_model
-from general import models as generalmodels
 from django.contrib import messages
-
+from events import models as event_models
 
 def make_player(request):
     try:
@@ -18,23 +17,24 @@ def make_player(request):
         p.save()
 
 
-def check_end():
-    return generalmodels.Variable.objects.get(name='orfikend').time <= timezone.now()
+def check_end(event):
+    return event.end_time <= timezone.now()
 
 
-def check_start():
-    return generalmodels.Variable.objects.get(name='orfikstart').time <= timezone.now()
+def check_start(event):
+    return event.start_time <= timezone.now()
 
 
 def home(request):
     data = {}
     template = 'orfik/home.html'
-    data['starttime'] = generalmodels.Variable.objects.get(name='orfikstart').time
-    data['started'] = check_start()
+    orfik = event_models.Event.objects.filter(appname='orfik', ongoing_event=True).order_by('start_time').last()
+    data['starttime'] = orfik.start_time
+    data['started'] = check_start(orfik)
     if request.user.is_authenticated():
         make_player(request)
         data['new_nick_form'] = models.NickForm()
-        ended = check_end()
+        ended = check_end(orfik)
         # Has orfik ended?
         if ended:
             data['endtime'] = ended
@@ -59,7 +59,8 @@ def instructions(request):
 def leader(request):
     data = {}
     template = 'orfik/leader.html'
-    endtime = generalmodels.Variable.objects.get(name='orfikend').time
+    orfik = event_models.Event.objects.filter(appname='orfik', ongoing_event=True).order_by('start_time').last()
+    endtime = orfik.end_time
     data['players'] = models.Player.objects.all().order_by('-max_level','last_solve')
     if endtime <= timezone.now():
         data['winner'] = data['players'][0]
@@ -69,7 +70,8 @@ def leader(request):
 @login_required
 def question(request, q_no):
     make_player(request)
-    starttime = generalmodels.Variable.objects.get(name='orfikstart').time
+    orfik = event_models.Event.objects.filter(appname='orfik', ongoing_event=True).order_by('start_time').last()
+    starttime = orfik.start_time
     player = request.user.player
     # Check if orfik has started
     if starttime > timezone.now():
@@ -86,7 +88,7 @@ def question(request, q_no):
     if request.method == 'GET':
         data['form'] = models.AnswerForm()
     if request.method == 'POST':
-        if check_end():
+        if check_end(orfik):
             return redirect('events:orfik:home')
         form = models.AnswerForm(request.POST)
         if question.number == player.max_level:  # This is his first potential

--- a/events/orfik/views.py
+++ b/events/orfik/views.py
@@ -28,7 +28,7 @@ def check_start(event):
 def home(request):
     data = {}
     template = 'orfik/home.html'
-    orfik = event_models.Event.objects.filter(appname='orfik', ongoing_event=True).order_by('start_time').last()
+    orfik = event_models.Event.objects.filter(appname='orfik').order_by('start_time').last()
     data['starttime'] = orfik.start_time
     data['started'] = check_start(orfik)
     if request.user.is_authenticated():
@@ -59,7 +59,7 @@ def instructions(request):
 def leader(request):
     data = {}
     template = 'orfik/leader.html'
-    orfik = event_models.Event.objects.filter(appname='orfik', ongoing_event=True).order_by('start_time').last()
+    orfik = event_models.Event.objects.filter(appname='orfik').order_by('start_time').last()
     endtime = orfik.end_time
     data['players'] = models.Player.objects.all().order_by('-max_level','last_solve')
     if endtime <= timezone.now():
@@ -70,7 +70,7 @@ def leader(request):
 @login_required
 def question(request, q_no):
     make_player(request)
-    orfik = event_models.Event.objects.filter(appname='orfik', ongoing_event=True).order_by('start_time').last()
+    orfik = event_models.Event.objects.filter(appname='orfik').order_by('start_time').last()
     starttime = orfik.start_time
     player = request.user.player
     # Check if orfik has started

--- a/general/models.py
+++ b/general/models.py
@@ -1,4 +1,5 @@
 from django.db import models
+import warnings
 from django.utils import timezone
 import requests
 
@@ -34,8 +35,15 @@ class CompMember(models.Model):
         return self.name
 
 
-class Variable(models.Model):
+class Variable(models.Model): ##NOTE: This should not be used anymore
     def __str__(self):
+        warnings.warn('''You are using a "General Variable".
+        Stop doing that.
+        This is bad design on Arjoonn's part so don't fall into the same trap.
+        If you are using this for Orfik, that has already been fixed. If you are using this for logos, same thing.
+
+        Over a few cycles this entire table will be removed.
+        '''
         return self.name
     name = models.CharField(max_length=100)
     time = models.DateTimeField()

--- a/website/settings/base.py
+++ b/website/settings/base.py
@@ -37,7 +37,7 @@ INSTALLED_APPS = (
     'general',
     'events',
     # 'events.logo',
-    # 'events.orfik',
+    'events.orfik',
     'metrics',
     # 'join',
     'import_export',

--- a/website/settings/base.py
+++ b/website/settings/base.py
@@ -36,7 +36,7 @@ INSTALLED_APPS = (
     # ---
     'general',
     'events',
-    # 'events.logo',
+    'events.logo',
     'events.orfik',
     'metrics',
     # 'join',


### PR DESCRIPTION
Events depended on General/Models/Variable earlier for start/end timestamps which made no sense. (It made sense when I wrote it but :man_shrugging: )

I've moved them out to a new structure. Here is the main gist of this branch:

- Event Creation
    - You create an event via `/admin`
    - An appname needs to be set in addition to everything else that was existing. This is one of 'orfik' or 'logo'.
    - In case new apps are added in the future, they may reference the app name to locate their configuration variables (See changes to know how).
    - The last event in the set of all events with the same appname ordered by start_time, is considered to be the last. This makes sense na?
- Settings
    - settings no longer need to be fiddled with to enable/disable events. That can be done via the `/admin` interface. (I think)


That's that for this branch.